### PR TITLE
CSS class name conflict with Atom editor causes bug with text entry

### DIFF
--- a/grammars/diff.cson
+++ b/grammars/diff.cson
@@ -22,7 +22,7 @@
       '1':
         'name': 'punctuation.definition.range.diff'
       '2':
-        'name': 'meta.toc-list.line-number.diff'
+        'name': 'meta.toc-list.coordinates.diff'
       '3':
         'name': 'punctuation.definition.range.diff'
     'match': '^(@@)\\s*(.+?)\\s*(@@)($\\n?)?'


### PR DESCRIPTION
One of the styles used for unified diffs uses the CSS class "line-number". However, this same class is used internally by the Atom editor, and the styles applied include horizontal padding. This causes Atom to display the cursor in the wrong location and therefore text typed appears at the shifted by one position.

The bug can be seen in this video:
https://goo.gl/photos/aHVTnZw6PTJAfSLp6

There is an easy fix: replace class "line-number" with something else, like "coordinates".
