### PR TITLE
Adapt to syntax theme

### DIFF
--- a/styles/diff.less
+++ b/styles/diff.less
@@ -1,3 +1,4 @@
+@import "syntax-variables";
 atom-text-editor::shadow {
   .diff {
     &.inserted {


### PR DESCRIPTION
With this patch,

![before](https://cloud.githubusercontent.com/assets/1498691/11079260/685291d2-884e-11e5-9d94-e487afc160fd.png)

becomes

![after](https://cloud.githubusercontent.com/assets/1498691/11079268/745bab26-884e-11e5-84a7-7c1535923147.png)

("Base16 Tomorrow Dark" theme is selected in this screenshot.)
