### PR TITLE
Avoid breaking patches by removing trailing whitespaces

### DIFF
--- a/settings/language-diff.cson
+++ b/settings/language-diff.cson
@@ -1,0 +1,3 @@
+'.source.diff':
+  whitespace:
+    removeTrailingWhitespace: false


### PR DESCRIPTION
The atom whitespaces package removes trailing whitespace by default.

This setting file makes sure, that trailing whitespace are never automatically deleted on save, to avoid breaking patches on save. 
