### PR TITLE
Remove deprecated Shadow DOM selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/miketheman/language-diff",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   },
   "dependencies": {},
   "devDependencies": {

--- a/styles/diff.less
+++ b/styles/diff.less
@@ -1,19 +1,19 @@
 @import "syntax-variables";
-atom-text-editor::shadow {
-  .diff {
-    &.inserted {
+atom-text-editor {
+  .syntax--diff {
+    &.syntax--inserted {
       color: @syntax-color-added;
     }
 
-    &.changed {
+    &.syntax--changed {
       color: @syntax-color-modified;
     }
 
-    &.deleted {
+    &.syntax--deleted {
       color: @syntax-color-removed;
     }
 
-    &.only-in {
+    &.syntax--only-in {
       // we don't have any methods in diff, so we can safely use this color
       color: @syntax-color-method;
       font-weight: bold;


### PR DESCRIPTION
This PR fixes the deprecation warnings displayed after upgrading to Atom 1.13, which has gotten rid of shadow DOM selectors.

I've also elevated the minimum required Atom version to ensure the updated version isn't installed by older Atom versions.