### PR TITLE
:shirt: Address deprecations for Atom 1.13

### DIFF
--- a/styles/diff.less
+++ b/styles/diff.less
@@ -1,19 +1,19 @@
 @import "syntax-variables";
-atom-text-editor::shadow {
-  .diff {
-    &.inserted {
+atom-text-editor {
+  .syntax--diff {
+    &.syntax--inserted {
       color: @syntax-color-added;
     }
 
-    &.changed {
+    &.syntax--changed {
       color: @syntax-color-modified;
     }
 
-    &.deleted {
+    &.syntax--deleted {
       color: @syntax-color-removed;
     }
 
-    &.only-in {
+    &.syntax--only-in {
       // we don't have any methods in diff, so we can safely use this color
       color: @syntax-color-method;
       font-weight: bold;


### PR DESCRIPTION
Ref: http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html

Resolves #7

Signed-off-by: Mike Fiedler <miketheman@gmail.com>